### PR TITLE
feat: add routing and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 #### To start the project `yarn start`
 
-#### To run tests `yarn test`
+#### To run tests and watch`yarn test`
 
-#### To run tests in watch mode `yarn test:watch`
+#### To run tests once withouth watch mode `yarn test:run`
 
 #### To run the linter `yarn lint`

--- a/README.md
+++ b/README.md
@@ -8,4 +8,6 @@
 
 #### To run tests `yarn test`
 
+#### To run tests in watch mode `yarn test:watch`
+
 #### To run the linter `yarn lint`

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "CI=true react-scripts test",
-    "test:watch": "react-scripts test",
+    "test": "react-scripts test",
+    "test:run": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src --color",
     "format": "pretty-quick"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
     "@types/node": "^12.0.0",
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
+    "@types/react-router-dom": "^5.1.4",
     "@types/styled-components": "^5.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
+    "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
     "styled-components": "^5.1.0",
     "typescript": "~3.7.2"
@@ -21,7 +23,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "CI=true react-scripts test",
+    "test:watch": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint --ext .ts,.tsx,.js,.jsx src --color",
     "format": "pretty-quick"

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "@types/react": "^16.9.0",
     "@types/react-dom": "^16.9.0",
     "@types/react-router-dom": "^5.1.4",
+    "@types/shortid": "^0.0.29",
     "@types/styled-components": "^5.1.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.4.1",
+    "shortid": "^2.2.15",
     "styled-components": "^5.1.0",
     "typescript": "~3.7.2"
   },

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,17 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { render } from '@testing-library/react';
 import App from './App';
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
 
   ReactDOM.render(<App />, div);
-});
-
-test('renders hello documents world', () => {
-  const { getByText } = render(<App />);
-  const textElement = getByText('Hello Documents World!');
-
-  expect(textElement).toBeInTheDocument();
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,42 @@
 import React, { ReactElement } from 'react';
-import ChangeBgColor from './ui/components/post-board/index';
+import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
+
+import createMuiTheme from '@material-ui/core/styles/createMuiTheme';
+import { ThemeProvider as MuiThemeProvider } from '@material-ui/core/styles';
+
+import themeColors from './ui/global/themeColors';
+import ChangeBgColor from './ui/components/post-board';
+import Navigation from './ui/components/navigation';
+import Home from './ui/views/home';
+import Signup from './ui/views/signup';
+import Login from './ui/views/login';
+
+const { black } = themeColors;
+
+// TODO: check theme colors for mui
+const theme = createMuiTheme({
+  palette: {
+    primary: {
+      main: black,
+    },
+  },
+});
 
 const App = (): ReactElement => {
   return (
-    <div className="App">
-      <h1
-        style={{
-          textAlign: 'center',
-        }}
-      >
-        Hello Documents World!
-      </h1>
+    <MuiThemeProvider theme={theme}>
+      <Router>
+        <Navigation />
 
-      <ChangeBgColor />
-    </div>
+        <Switch>
+          <Route exact path="/" component={Home} />
+          <Route exact path="/signup" component={Signup} />
+          <Route exact path="/login" component={Login} />
+        </Switch>
+
+        <ChangeBgColor />
+      </Router>
+    </MuiThemeProvider>
   );
 };
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,1 @@
+export * from './navigation.interface';

--- a/src/interfaces/navigation.interface.ts
+++ b/src/interfaces/navigation.interface.ts
@@ -1,0 +1,4 @@
+export interface NavigationLink {
+  name: string;
+  target: string;
+}

--- a/src/ui/components/navigation/Navigation.test.tsx
+++ b/src/ui/components/navigation/Navigation.test.tsx
@@ -16,17 +16,16 @@ it('renders without crashing', () => {
   );
 });
 
-it('should render all links in navigation', () => {
-  const { getByText } = render(
-    <Router>
-      <Navigation />
-    </Router>,
-  );
-  const homeButton = getByText('Home');
-  const loginButton = getByText('Login');
-  const signupButton = getByText('Login');
+it.each(['Home', 'Login', 'Signup'])(
+  'should render %s link in navigation',
+  (linkText: string) => {
+    const { getByText } = render(
+      <Router>
+        <Navigation />
+      </Router>,
+    );
+    const link = getByText(linkText);
 
-  expect(homeButton).toBeInTheDocument();
-  expect(loginButton).toBeInTheDocument();
-  expect(signupButton).toBeInTheDocument();
-});
+    expect(link).toBeInTheDocument();
+  },
+);

--- a/src/ui/components/navigation/Navigation.test.tsx
+++ b/src/ui/components/navigation/Navigation.test.tsx
@@ -1,31 +1,19 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { render } from '@testing-library/react';
+import { BrowserRouter as Router } from 'react-router-dom';
+
 import Navigation from './Navigation';
 
-import { BrowserRouter as Router } from 'react-router-dom';
+const navInRouter = (): React.ReactElement => {
+  return (
+    <Router>
+      <Navigation />
+    </Router>
+  );
+};
 
 it('renders without crashing', () => {
   const div = document.createElement('div');
 
-  ReactDOM.render(
-    <Router>
-      <Navigation />
-    </Router>,
-    div,
-  );
+  ReactDOM.render(navInRouter(), div);
 });
-
-it.each(['Home', 'Login', 'Signup'])(
-  'should render %s link in navigation',
-  (linkText: string) => {
-    const { getByText } = render(
-      <Router>
-        <Navigation />
-      </Router>,
-    );
-    const link = getByText(linkText);
-
-    expect(link).toBeInTheDocument();
-  },
-);

--- a/src/ui/components/navigation/Navigation.test.tsx
+++ b/src/ui/components/navigation/Navigation.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
+import Navigation from './Navigation';
+
+import { BrowserRouter as Router } from 'react-router-dom';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+
+  ReactDOM.render(
+    <Router>
+      <Navigation />
+    </Router>,
+    div,
+  );
+});
+
+it('should render all links in navigation', () => {
+  const { getByText } = render(
+    <Router>
+      <Navigation />
+    </Router>,
+  );
+  const homeButton = getByText('Home');
+  const loginButton = getByText('Login');
+  const signupButton = getByText('Login');
+
+  expect(homeButton).toBeInTheDocument();
+  expect(loginButton).toBeInTheDocument();
+  expect(signupButton).toBeInTheDocument();
+});

--- a/src/ui/components/navigation/Navigation.test.tsx
+++ b/src/ui/components/navigation/Navigation.test.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 
 import Navigation from './Navigation';
 
-const navInRouter = (): React.ReactElement => {
+const renderNavInRouter = (): React.ReactElement => {
   return (
     <Router>
       <Navigation />
@@ -15,5 +15,5 @@ const navInRouter = (): React.ReactElement => {
 it('renders without crashing', () => {
   const div = document.createElement('div');
 
-  ReactDOM.render(navInRouter(), div);
+  ReactDOM.render(renderNavInRouter(), div);
 });

--- a/src/ui/components/navigation/Navigation.tsx
+++ b/src/ui/components/navigation/Navigation.tsx
@@ -1,24 +1,16 @@
 import React, { FunctionComponent } from 'react';
 
-import { Link } from 'react-router-dom';
-
 import AppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
-import Button from '@material-ui/core/Button';
+
+import NAVIGATION_LINKS from '../../global/navigation';
+import RouterLinks from '../router-links';
 
 const Navigation: FunctionComponent = () => {
   return (
     <AppBar color="primary" position="static">
       <Toolbar className="nav-container">
-        <Button color="inherit" component={Link} to="/">
-          Home
-        </Button>
-        <Button color="inherit" component={Link} to="/login">
-          Login
-        </Button>
-        <Button color="inherit" component={Link} to="/signup">
-          Signup
-        </Button>
+        <RouterLinks links={NAVIGATION_LINKS}></RouterLinks>
       </Toolbar>
     </AppBar>
   );

--- a/src/ui/components/navigation/Navigation.tsx
+++ b/src/ui/components/navigation/Navigation.tsx
@@ -1,0 +1,27 @@
+import React, { FunctionComponent } from 'react';
+
+import { Link } from 'react-router-dom';
+
+import AppBar from '@material-ui/core/AppBar';
+import Toolbar from '@material-ui/core/Toolbar';
+import Button from '@material-ui/core/Button';
+
+const Navigation: FunctionComponent = () => {
+  return (
+    <AppBar color="primary" position="static">
+      <Toolbar className="nav-container">
+        <Button color="inherit" component={Link} to="/">
+          Home
+        </Button>
+        <Button color="inherit" component={Link} to="/login">
+          Login
+        </Button>
+        <Button color="inherit" component={Link} to="/signup">
+          Signup
+        </Button>
+      </Toolbar>
+    </AppBar>
+  );
+};
+
+export default Navigation;

--- a/src/ui/components/navigation/index.ts
+++ b/src/ui/components/navigation/index.ts
@@ -1,0 +1,3 @@
+import Navigation from './Navigation';
+
+export default Navigation;

--- a/src/ui/components/post-board/ChangeBgColor.tsx
+++ b/src/ui/components/post-board/ChangeBgColor.tsx
@@ -11,7 +11,7 @@ const ChangeBgColor: FunctionComponent = () => {
 
   const changeBackground = (
     event: React.ChangeEvent<HTMLInputElement>,
-  ): any => {
+  ): void => {
     setDarkMode(event.target.checked);
   };
 

--- a/src/ui/components/router-links/RouterLinks.test.tsx
+++ b/src/ui/components/router-links/RouterLinks.test.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { render } from '@testing-library/react';
+
+import RouterLinks from './RouterLinks';
+import { NavigationLink } from '../../../interfaces';
+
+const MOCK_LINKS: NavigationLink[] = [
+  {
+    name: 'Test',
+    target: '/Test',
+  },
+  {
+    name: 'Somewhere',
+    target: '/somewhere',
+  },
+  {
+    name: 'Unknown',
+    target: '/unknown',
+  },
+];
+
+const printLinksInRouter = (links = MOCK_LINKS): React.ReactElement => {
+  return (
+    <Router>
+      <RouterLinks links={links} />
+    </Router>
+  );
+};
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+
+  ReactDOM.render(printLinksInRouter(), div);
+});
+
+it.each(MOCK_LINKS.map((link) => link.name))(
+  'should render %s link in navigation',
+  (linkText: string) => {
+    const { getByText } = render(printLinksInRouter());
+    const link = getByText(linkText);
+
+    expect(link).toBeInTheDocument();
+  },
+);

--- a/src/ui/components/router-links/RouterLinks.test.tsx
+++ b/src/ui/components/router-links/RouterLinks.test.tsx
@@ -21,7 +21,7 @@ const MOCK_LINKS: NavigationLink[] = [
   },
 ];
 
-const printLinksInRouter = (links = MOCK_LINKS): React.ReactElement => {
+const renderLinksInRouter = (links = MOCK_LINKS): React.ReactElement => {
   return (
     <Router>
       <RouterLinks links={links} />
@@ -32,13 +32,13 @@ const printLinksInRouter = (links = MOCK_LINKS): React.ReactElement => {
 it('renders without crashing', () => {
   const div = document.createElement('div');
 
-  ReactDOM.render(printLinksInRouter(), div);
+  ReactDOM.render(renderLinksInRouter(), div);
 });
 
 it.each(MOCK_LINKS.map((link) => link.name))(
   'should render %s link in navigation',
   (linkText: string) => {
-    const { getByText } = render(printLinksInRouter());
+    const { getByText } = render(renderLinksInRouter());
     const link = getByText(linkText);
 
     expect(link).toBeInTheDocument();

--- a/src/ui/components/router-links/RouterLinks.tsx
+++ b/src/ui/components/router-links/RouterLinks.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React, { FunctionComponent, Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import { generate as generateId } from 'shortid';
 
@@ -12,7 +12,7 @@ interface RouterLinksProps {
 
 const RouterLinks: FunctionComponent<RouterLinksProps> = ({ links }) => {
   return (
-    <React.Fragment>
+    <Fragment>
       {links.map((link) => (
         <Button
           color="inherit"
@@ -23,7 +23,7 @@ const RouterLinks: FunctionComponent<RouterLinksProps> = ({ links }) => {
           {link.name}
         </Button>
       ))}
-    </React.Fragment>
+    </Fragment>
   );
 };
 

--- a/src/ui/components/router-links/RouterLinks.tsx
+++ b/src/ui/components/router-links/RouterLinks.tsx
@@ -13,14 +13,14 @@ interface RouterLinksProps {
 const RouterLinks: FunctionComponent<RouterLinksProps> = ({ links }) => {
   return (
     <Fragment>
-      {links.map((link) => (
+      {links.map(({ name, target }) => (
         <Button
           color="inherit"
           key={'router-link-' + generateId()}
           component={Link}
-          to={link.target}
+          to={target}
         >
-          {link.name}
+          {name}
         </Button>
       ))}
     </Fragment>

--- a/src/ui/components/router-links/RouterLinks.tsx
+++ b/src/ui/components/router-links/RouterLinks.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react';
 import { Link } from 'react-router-dom';
-import * as shortid from 'shortid';
+import { generate as generateId } from 'shortid';
 
 import Button from '@material-ui/core/Button';
 
@@ -16,7 +16,7 @@ const RouterLinks: FunctionComponent<RouterLinksProps> = ({ links }) => {
       {links.map((link) => (
         <Button
           color="inherit"
-          key={'router-link' + shortid.generate()}
+          key={'router-link-' + generateId()}
           component={Link}
           to={link.target}
         >

--- a/src/ui/components/router-links/RouterLinks.tsx
+++ b/src/ui/components/router-links/RouterLinks.tsx
@@ -1,0 +1,30 @@
+import React, { FunctionComponent } from 'react';
+import { Link } from 'react-router-dom';
+import * as shortid from 'shortid';
+
+import Button from '@material-ui/core/Button';
+
+import { NavigationLink } from '../../../interfaces';
+
+interface RouterLinksProps {
+  links: NavigationLink[];
+}
+
+const RouterLinks: FunctionComponent<RouterLinksProps> = ({ links }) => {
+  return (
+    <React.Fragment>
+      {links.map((link) => (
+        <Button
+          color="inherit"
+          key={'router-link' + shortid.generate()}
+          component={Link}
+          to={link.target}
+        >
+          {link.name}
+        </Button>
+      ))}
+    </React.Fragment>
+  );
+};
+
+export default RouterLinks;

--- a/src/ui/components/router-links/index.ts
+++ b/src/ui/components/router-links/index.ts
@@ -1,0 +1,3 @@
+import RouterLinks from './RouterLinks';
+
+export default RouterLinks;

--- a/src/ui/global/navigation.ts
+++ b/src/ui/global/navigation.ts
@@ -1,0 +1,18 @@
+import { NavigationLink } from '../../interfaces';
+
+const NAVIGATION_LINKS: NavigationLink[] = [
+  {
+    name: 'Home',
+    target: '/',
+  },
+  {
+    name: 'Login',
+    target: '/login',
+  },
+  {
+    name: 'Signup',
+    target: '/signup',
+  },
+];
+
+export default NAVIGATION_LINKS;

--- a/src/ui/views/home/Home.test.tsx
+++ b/src/ui/views/home/Home.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
+import Home from './Home';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+
+  ReactDOM.render(<Home />, div);
+});
+
+it('should render heading', () => {
+  const { getByText } = render(<Home />);
+  const heading = getByText('Hello Documents World!');
+
+  expect(heading).toBeInTheDocument();
+});

--- a/src/ui/views/home/Home.tsx
+++ b/src/ui/views/home/Home.tsx
@@ -1,0 +1,15 @@
+import React, { FunctionComponent } from 'react';
+
+const Home: FunctionComponent = () => {
+  return (
+    <h1
+      style={{
+        textAlign: 'center',
+      }}
+    >
+      Hello Documents World!
+    </h1>
+  );
+};
+
+export default Home;

--- a/src/ui/views/home/index.ts
+++ b/src/ui/views/home/index.ts
@@ -1,0 +1,3 @@
+import Home from './Home';
+
+export default Home;

--- a/src/ui/views/login/Login.test.tsx
+++ b/src/ui/views/login/Login.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
+import Login from './Login';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+
+  ReactDOM.render(<Login />, div);
+});
+
+it('should render heading', () => {
+  const { getByText } = render(<Login />);
+  const heading = getByText('Log in here');
+
+  expect(heading).toBeInTheDocument();
+});

--- a/src/ui/views/login/Login.tsx
+++ b/src/ui/views/login/Login.tsx
@@ -1,0 +1,15 @@
+import React, { FunctionComponent } from 'react';
+
+const Login: FunctionComponent = () => {
+  return (
+    <h1
+      style={{
+        textAlign: 'center',
+      }}
+    >
+      Log in here
+    </h1>
+  );
+};
+
+export default Login;

--- a/src/ui/views/login/index.ts
+++ b/src/ui/views/login/index.ts
@@ -1,0 +1,3 @@
+import Login from './Login';
+
+export default Login;

--- a/src/ui/views/signup/Home.test.tsx
+++ b/src/ui/views/signup/Home.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { render } from '@testing-library/react';
+import Signup from './Signup';
+
+it('renders without crashing', () => {
+  const div = document.createElement('div');
+
+  ReactDOM.render(<Signup />, div);
+});
+
+it('should render heading', () => {
+  const { getByText } = render(<Signup />);
+  const heading = getByText('Sigun up here');
+
+  expect(heading).toBeInTheDocument();
+});

--- a/src/ui/views/signup/Signup.tsx
+++ b/src/ui/views/signup/Signup.tsx
@@ -1,0 +1,15 @@
+import React, { FunctionComponent } from 'react';
+
+const Signup: FunctionComponent = () => {
+  return (
+    <h1
+      style={{
+        textAlign: 'center',
+      }}
+    >
+      Sigun up here
+    </h1>
+  );
+};
+
+export default Signup;

--- a/src/ui/views/signup/index.ts
+++ b/src/ui/views/signup/index.ts
@@ -1,0 +1,3 @@
+import Signup from './Signup';
+
+export default Signup;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,6 +1663,11 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
+"@types/shortid@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/shortid/-/shortid-0.0.29.tgz#8093ee0416a6e2bf2aa6338109114b3fbffa0e9b"
+  integrity sha1-gJPuBBam4r8qpjOBCRFLP7/6Dps=
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -7489,6 +7494,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
+nanoid@^2.1.0:
+  version "2.1.11"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.1.11.tgz#ec24b8a758d591561531b4176a01e3ab4f0f0280"
+  integrity sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -10095,6 +10105,13 @@ shellwords@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
   integrity sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
+shortid@^2.2.15:
+  version "2.2.15"
+  resolved "https://registry.yarnpkg.com/shortid/-/shortid-2.2.15.tgz#2b902eaa93a69b11120373cd42a1f1fe4437c122"
+  integrity sha512-5EaCy2mx2Jgc/Fdn9uuDuNIIfWBpzY4XIlhoqtXF6qsf+/+SGZ+FxDdX/ZsMZiWupIWNqAEmiNY4RC+LSmCeOw==
+  dependencies:
+    nanoid "^2.1.0"
 
 side-channel@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -966,7 +966,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.4.0", "@babel/runtime@^7.4.4", "@babel/runtime@^7.4.5", "@babel/runtime@^7.5.1", "@babel/runtime@^7.5.5", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.4", "@babel/runtime@^7.8.3", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7":
   version "7.9.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.9.2.tgz#d90df0583a3a252f09aaa619665367bae518db06"
   integrity sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==
@@ -1542,6 +1542,11 @@
     "@types/minimatch" "*"
     "@types/node" "*"
 
+"@types/history@*":
+  version "4.7.5"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.5.tgz#527d20ef68571a4af02ed74350164e7a67544860"
+  integrity sha512-wLD/Aq2VggCJXSjxEwrMafIP51Z+13H78nXIX0ABEuIGhmB5sNGbR113MOKo+yfw+RDo1ZU3DM6yfnnRF/+ouw==
+
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -1624,6 +1629,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.62.2.tgz#f3e150f308c27089cefbcbfa3eb6cc14db279b2f"
   integrity sha512-oIUIbqZNN9vRnGKWHYbTVp/GyTqdaM5mfy1s4zsi6BYvHAaFOPZ32IrhIHno/A5XOv4wuGfE7g5fliDk/H0+/Q==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.1.4.tgz#8d3e0306df74af301cc896309e7d4758f1a4bf71"
+  integrity sha512-LO0z5qqSfWdYtCNsRm8/OMnnkv52hwADJKrAfpKIyfHclORllcgAMGypEA7ajHm38+jOonKLx8nPygNAAZGxtg==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.5.tgz#7b2f9b7cc3d350e92664c4e38c0ef529286fe628"
+  integrity sha512-RZPdCtZympi6X7EkGyaU7ISiAujDYTWgqMF9owE3P6efITw27IWQykcti0BvA5h4Mu1LLl5rxrpO3r8kHyUZ/Q==
+  dependencies:
+    "@types/history" "*"
     "@types/react" "*"
 
 "@types/react-transition-group@^4.2.0":
@@ -5177,6 +5199,11 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
+gud@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/gud/-/gud-1.0.0.tgz#a489581b17e6a70beca9abe3ae57de7a499852c0"
+  integrity sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==
+
 gzip-size@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
@@ -5294,6 +5321,18 @@ hex-color-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
   integrity sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==
 
+history@^4.9.0:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/history/-/history-4.10.1.tgz#33371a65e3a83b267434e2b3f3b1b4c58aad4cf3"
+  integrity sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    loose-envify "^1.2.0"
+    resolve-pathname "^3.0.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+    value-equal "^1.0.1"
+
 hmac-drbg@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/hmac-drbg/-/hmac-drbg-1.0.1.tgz#d2745701025a6c775a6c545793ed502fc0c649a1"
@@ -5303,7 +5342,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6041,6 +6080,11 @@ is-wsl@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
   integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -7049,7 +7093,7 @@ loglevel@^1.6.6:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.8.tgz#8a25fb75d092230ecd4457270d80b54e28011171"
   integrity sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
+loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   integrity sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==
@@ -7270,6 +7314,15 @@ min-indent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.0.tgz#cfc45c37e9ec0d8f0a0ec3dd4ef7f7c3abe39256"
   integrity sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=
+
+mini-create-react-context@^0.3.0:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz#79fc598f283dd623da8e088b05db8cddab250189"
+  integrity sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==
+  dependencies:
+    "@babel/runtime" "^7.4.0"
+    gud "^1.0.0"
+    tiny-warning "^1.0.2"
 
 mini-css-extract-plugin@0.9.0:
   version "0.9.0"
@@ -8090,6 +8143,13 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
   integrity sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^2.0.0:
   version "2.0.0"
@@ -9224,10 +9284,39 @@ react-error-overlay@^6.0.7:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.7.tgz#1dcfb459ab671d53f660a991513cb2f0a0553108"
   integrity sha512-TAv1KJFh3RhqxNvhzxj6LeT5NWklP6rDr2a0jaTfsZ5wSZWHOGeqQyejUp3xxLfPt2UpyJEcVQB/zyPcmonNFA==
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4:
+react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-is@^16.8.1, react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-router-dom@^5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.1.2.tgz#06701b834352f44d37fbb6311f870f84c76b9c18"
+  integrity sha512-7BPHAaIwWpZS074UKaw1FjVdZBSVWEk8IuDXdB+OkLb8vd/WRQIpA4ag9WQk61aEfQs47wHyjWUoUGGZxpQXew==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.1.2"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.1.2:
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.1.2.tgz#6ea51d789cb36a6be1ba5f7c0d48dd9e817d3418"
+  integrity sha512-yjEuMFy1ONK246B+rsa0cUam5OeAQ8pyclRDgpxuSCrAlJ1qN9uZ5IgyKC7gQg0w8OM50NXHEegPh/ks9YuR2A==
+  dependencies:
+    "@babel/runtime" "^7.1.2"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
+    mini-create-react-context "^0.3.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
 
 react-scripts@3.4.1:
   version "3.4.1"
@@ -9596,6 +9685,11 @@ resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
   integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+resolve-pathname@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pathname/-/resolve-pathname-3.0.0.tgz#99d02224d3cf263689becbb393bc560313025dcd"
+  integrity sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng==
 
 resolve-url-loader@3.1.1:
   version "3.1.1"
@@ -10693,7 +10787,12 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-warning@^1.0.2:
+tiny-invariant@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.1.0.tgz#634c5f8efdc27714b7f386c35e6760991d230875"
+  integrity sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw==
+
+tiny-warning@^1.0.0, tiny-warning@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
   integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
@@ -11047,6 +11146,11 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
+
+value-equal@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/value-equal/-/value-equal-1.0.1.tgz#1e0b794c734c5c0cade179c437d356d931a34d6c"
+  integrity sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
- adds routing
- adds navigation component with three links
- adds placeholder components for different views
- changes so tests are not watching by default
- adds theme for material ui (only one colour, needs to be worked on)

Probably would be nice to customise the navigation a bit later, added just some default components. Also needs still the search input that we discussed